### PR TITLE
Feat: Update Sender email uniqueness constraint and FacilitySeeder location

### DIFF
--- a/database/migrations/2024_02_10_164225_create_senders_table.php
+++ b/database/migrations/2024_02_10_164225_create_senders_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('senders', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email');
             $table->string('phone');
             $table->bigInteger('address_id')->unsigned();
             $table->timestamps();

--- a/database/migrations/2024_02_10_164234_create_recipients_table.php
+++ b/database/migrations/2024_02_10_164234_create_recipients_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('recipients', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('email')->unique();
+            $table->string('email');
             $table->string('phone');
             $table->bigInteger('address_id')->unsigned();
             $table->bigInteger('near_facility_id')->unsigned();

--- a/database/seeders/FacilitySeeder.php
+++ b/database/seeders/FacilitySeeder.php
@@ -43,7 +43,7 @@ class FacilitySeeder extends Seeder
             ],
             [
                 'name' => 'Distribution center',
-                'location' => 'Khartoum',
+                'location' => 'Omdurman',
             ],
         ];
 


### PR DESCRIPTION
This pull request introduces two key changes to enhance the functionality and accuracy of the application's data management:

**Update Sender and Recipient Email Uniqueness Constraint:**
The migration files for senders and recipients has been modified to remove the unique() constraint from the email field in the senders and recipients tables. This change was made to accommodate scenarios where a sender/recipient may have multiple shipments. Removing the uniqueness constraint allows for inserting sender/recipient data without triggering errors related to duplicate email entries.

**Modify FacilitySeeder Location:**
In the FacilitySeeder.php seeder file, the location of the Distribution center has been updated from 'Khartoum' to 'Omdurman'. This correction addresses a previous mistake where a duplicate value was inadvertently created during the seeding process. The updated location ensures accuracy and consistency in the seeded data, reflecting the correct location of the Distribution center.

These changes contribute to improved data management and accuracy within the application, aligning the system more closely with user expectations and requirements.