### PR TITLE
Fix issue with filling line reaching last destination in Tracking page

### DIFF
--- a/resources/js/Pages/Tracking.vue
+++ b/resources/js/Pages/Tracking.vue
@@ -134,7 +134,8 @@ function fillingLineWidth(index) {
                             <div class="mt-1 text-xs text-green-400 font-extrabold">{{ city }}</div>
                         </div>
                         <!-- Filling line between cities -->
-                        <div v-if="index < routeCities.length - 1" class="filling-line" :style="{ width: fillingLineWidth(index) + '%' }"></div>
+                        <div v-if="index < routeCities.length" class="filling-line" :style="{ width: fillingLineWidth(index) + '%' }"></div>
+
                     </template>
                 </div>
             </div>


### PR DESCRIPTION
- Resolves an issue in the Tracking page where the filling line representing the package location was not reaching the last destination despite the package being delivered.

- Previously, the condition for displaying the filling line between cities was based on the index being less than the length of routeCities minus one, which caused the line to stop before reaching the final destination.

- To fix this, I updated the condition to ensure that the filling line is displayed for all cities in the route, allowing it to reach the last destination even after delivery.