### PR TITLE
Trim token value in shipment search

### DIFF
--- a/resources/js/Pages/Tracking.vue
+++ b/resources/js/Pages/Tracking.vue
@@ -25,7 +25,7 @@ onMounted(async () => {
 const searchByToken = async () => {
     try {
         // Fetch shipment details from the backend using the provided token
-        const shipmentsResponse = await axios.get(`/api/shipments/${token.value}`);
+        const shipmentsResponse = await axios.get(`/api/shipments/${token.value.trim()}`);
         shipments.value = shipmentsResponse.data;
         routeCities.value = findRoute(shipments.value.facility.location, shipments.value.recipient.facility.location, cities.value);
         currentCityPosition.value = routeCities.value.indexOf(shipments.value.user.facility.location);


### PR DESCRIPTION
Trimmed the token value obtained from the input
field in the shipment search to remove any leading
or trailing whitespace. This ensures accurate
retrieval of shipment details from the backend API.