### PR TITLE
Add qr_code_image Field to Shipment Model and Shipments Table Migration

### DIFF
--- a/app/Models/Shipment.php
+++ b/app/Models/Shipment.php
@@ -48,6 +48,7 @@ class Shipment extends Model
         'status_id',
         'origin_facility_id',
         'tracking_token',
+        'qr_code_image',
     ];
 
     public function item()

--- a/database/migrations/2024_02_10_164243_create_shipments_table.php
+++ b/database/migrations/2024_02_10_164243_create_shipments_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->BigInteger('status_id')->unsigned()->default(1); // Set default value to 1
             $table->BigInteger('origin_facility_id')->unsigned();
             $table->string('tracking_token');
+            $table->string('qr_code_image');
             $table->timestamps();
 
             $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');


### PR DESCRIPTION
This pull request introduces the addition of a new field qr_code_image to both the Shipment model and the shipments table migration. The qr_code_image field will be used to store the path of the QR code image associated with each shipment.

**Changes:**

* Added the qr_code_image field to the Shipment model's fillable array.
* Modified the create_shipments_table migration to include the qr_code_image field in the shipments table schema.

**Purpose:**

The purpose of this change is to facilitate the storage of QR code images for shipments, enabling the application to generate and associate QR codes with each shipment.

**Affected Files:**
* app/Models/Shipment.php
* database/migrations/2024_02_10_164243_create_shipments_table.php