### PR TITLE
 Handle failure in shipment status update

### DIFF
--- a/app/Http/Controllers/ShipmentsController.php
+++ b/app/Http/Controllers/ShipmentsController.php
@@ -331,7 +331,9 @@ class ShipmentsController extends Controller
 
         } catch (\Exception $e) {
             // Handle any errors
-            return response()->json(['error' => 'Failed to update shipment status via QR code'], 400);
+            $message = 'Error update Shipment status';
+            // Redirect to the user dashboard with a success message as query parameter
+            return redirect()->route('user.dashboard', ['status' => $message]);
         }
     }
 

--- a/resources/js/Pages/User-Dashboard.vue
+++ b/resources/js/Pages/User-Dashboard.vue
@@ -62,6 +62,8 @@ onMounted(async () => {
         if (status === 'Shipment status updated successfully') {
             // If it matches, call the showNotification function to display the confirmation
             showNotification(status);
+        } else if (status && status !== 'Shipment status updated successfully') {
+            alert('Error updating the shipment status')
         }
 
     } catch (error) {


### PR DESCRIPTION
This pull request addresses the need to handle failures in the shipment status update process. Two main changes were made:

* In ShipmentsController.php, in the catch block within updateStatusViaQR method Upon failure, a redirect to the user dashboard with an error message as a query parameter is now triggered.

* In User-Dashboard.vue, the onMounted hook was updated to display an alert when the shipment status update fails. This alert notifies the user about the failure in updating the shipment status.

These changes ensure better user experience by providing immediate feedback in case of errors during the shipment status update process.