### PR TITLE
Add Dynamic States and Localities Support

### DIFF
--- a/app/Models/Locality.php
+++ b/app/Models/Locality.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\State;
+
+class Locality extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'state_id'];
+
+    public function state()
+    {
+        return $this->belongsTo(State::class);
+    }
+
+}

--- a/app/Models/State.php
+++ b/app/Models/State.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Locality;
+
+class State extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function localities()
+    {
+        return $this->hasMany(Locality::class);
+    }
+
+}

--- a/database/migrations/2024_03_21_002755_create_states_table.php
+++ b/database/migrations/2024_03_21_002755_create_states_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('states', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('states');
+    }
+};

--- a/database/migrations/2024_03_21_002816_create_localities_table.php
+++ b/database/migrations/2024_03_21_002816_create_localities_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('localities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedBigInteger('state_id');
+            $table->timestamps();
+
+            $table->foreign('state_id')->references('id')->on('states')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('localities');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,5 +22,7 @@ class DatabaseSeeder extends Seeder
         $this->call(FacilitySeeder::class);
         $this->call(StatusSeeder::class);
         $this->call(CitySeeder::class);
+        $this->call(StateSeeder::class);
+        $this->call(LocalitySeeder::class);
     }
 }

--- a/database/seeders/LocalitySeeder.php
+++ b/database/seeders/LocalitySeeder.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Locality;
+
+class LocalitySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $localities = [
+            // البحر الأحمر (1)
+            ['name' => 'جييت', 'state_id' => 1],
+            ['name' => 'بورتسودان', 'state_id' => 1],
+            ['name' => 'القوليب وأوليب', 'state_id' => 1],
+            ['name' => 'حلايب', 'state_id' => 1],
+            ['name' => 'درديب', 'state_id' => 1],
+            ['name' => 'سنكات', 'state_id' => 1],
+            ['name' => 'سواكن', 'state_id' => 1],
+            ['name' => 'طوكر', 'state_id' => 1],
+            ['name' => 'هيا', 'state_id' => 1],
+
+            // الجزيرة (2)
+            ['name' => 'الحصاحيصا', 'state_id' => 2],
+            ['name' => 'الكاملين', 'state_id' => 2],
+            ['name' => 'المناقل', 'state_id' => 2],
+            ['name' => 'أم القرى', 'state_id' => 2],
+            ['name' => 'جنوب الجزيرة', 'state_id' => 2],
+            ['name' => 'شرق الجزيرة', 'state_id' => 2],
+            ['name' => 'مدني الكبرى', 'state_id' => 2],
+
+            // الخرطوم (3)
+            ['name' => 'الخرطوم', 'state_id' => 3],
+            ['name' => 'بحري', 'state_id' => 3],
+            ['name' => 'أم بدة', 'state_id' => 3],
+            ['name' => 'أم درمان', 'state_id' => 3],
+            ['name' => 'جبل أولياء', 'state_id' => 3],
+            ['name' => 'كرري', 'state_id' => 3],
+            ['name' => 'شرق النيل', 'state_id' => 3],
+
+            // الشمالية (4)
+            ['name' => 'الدبة', 'state_id' => 4],
+            ['name' => 'دنقلا', 'state_id' => 4],
+            ['name' => 'مروي', 'state_id' => 4],
+            ['name' => 'وادي حلفا', 'state_id' => 4],
+
+            // القضارف (5)
+            ['name' => 'البطانة', 'state_id' => 5],
+            ['name' => 'الرهد', 'state_id' => 5],
+            ['name' => 'الفاو', 'state_id' => 5],
+            ['name' => 'الفشقة', 'state_id' => 5],
+            ['name' => 'القريشة', 'state_id' => 5],
+            ['name' => 'القلابات الشرقية', 'state_id' => 5],
+            ['name' => 'القلابات الغربية', 'state_id' => 5],
+            ['name' => 'بلدية القضارف', 'state_id' => 5],
+            ['name' => 'قلع النحل', 'state_id' => 5],
+
+            // النيل الأبيض (6)
+            ['name' => 'الجبلين', 'state_id' => 6],
+            ['name' => 'الدويم', 'state_id' => 6],
+            ['name' => 'القطينة', 'state_id' => 6],
+            ['name' => 'أم رمته', 'state_id' => 6],
+            ['name' => 'كوستي', 'state_id' => 6],
+
+            // النيل الأزرق (7)
+            ['name' => 'الدمازين', 'state_id' => 7],
+            ['name' => 'الروصيرص', 'state_id' => 7],
+            ['name' => 'الكرمك', 'state_id' => 7],
+            ['name' => 'باو', 'state_id' => 7],
+            ['name' => 'قيسان', 'state_id' => 7],
+
+            // جنوب دارفور (8)
+            ['name' => 'الردوم', 'state_id' => 8],
+            ['name' => 'السلام', 'state_id' => 8],
+            ['name' => 'السنطة', 'state_id' => 8],
+            ['name' => 'الوحدة', 'state_id' => 8],
+            ['name' => 'أم دافوق', 'state_id' => 8],
+            ['name' => 'بليل', 'state_id' => 8],
+            ['name' => 'تلس', 'state_id' => 8],
+            ['name' => 'دمسو', 'state_id' => 8],
+            ['name' => 'رهيد البردي', 'state_id' => 8],
+            ['name' => 'شاطايا', 'state_id' => 8],
+            ['name' => 'شرق الجبل', 'state_id' => 8],
+            ['name' => 'عد الفرسان', 'state_id' => 8],
+            ['name' => 'قريضة', 'state_id' => 8],
+            ['name' => 'كاس', 'state_id' => 8],
+            ['name' => 'كتم', 'state_id' => 8],
+            ['name' => 'كنيلا', 'state_id' => 8],
+            ['name' => 'مرشنج', 'state_id' => 8],
+            ['name' => 'نتيقا', 'state_id' => 8],
+            ['name' => 'نيالا', 'state_id' => 8],
+
+            // جنوب كردفان (9)
+            ['name' => 'الدلنج', 'state_id' => 9],
+            ['name' => 'الريف الشرقي', 'state_id' => 9],
+            ['name' => 'السلام', 'state_id' => 9],
+            ['name' => 'العباسية', 'state_id' => 9],
+            ['name' => 'القوز', 'state_id' => 9],
+            ['name' => 'أبو جبيهة', 'state_id' => 9],
+            ['name' => 'أم دورين', 'state_id' => 9],
+            ['name' => 'برام', 'state_id' => 9],
+            ['name' => 'تلودي', 'state_id' => 9],
+            ['name' => 'دلامي', 'state_id' => 9],
+            ['name' => 'رشاد', 'state_id' => 9],
+            ['name' => 'كادقلي', 'state_id' => 9],
+            ['name' => 'كليك', 'state_id' => 9],
+            ['name' => 'هبيلا', 'state_id' => 9],
+            ['name' => 'هيبان', 'state_id' => 9],
+
+            // سنار (10)
+            ['name' => 'الدندر', 'state_id' => 10],
+            ['name' => 'سنار', 'state_id' => 10],
+            ['name' => 'سنجة', 'state_id' => 10],
+
+            // شرق دارفور (11)
+            ['name' => 'الضعين', 'state_id' => 11],
+            ['name' => 'الفردوس', 'state_id' => 11],
+            ['name' => 'أبو جابرة', 'state_id' => 11],
+            ['name' => 'أبو كارنكا', 'state_id' => 11],
+            ['name' => 'بحر العرب', 'state_id' => 11],
+            ['name' => 'شعيرية', 'state_id' => 11],
+            ['name' => 'عديلة', 'state_id' => 11],
+            ['name' => 'عسلاية', 'state_id' => 11],
+            ['name' => 'ياسين', 'state_id' => 11],
+
+            // شمال دارفور (12)
+            ['name' => 'الفاشر', 'state_id' => 12],
+            ['name' => 'أم كدادة', 'state_id' => 12],
+            ['name' => 'كبكابية', 'state_id' => 12],
+            ['name' => 'كتم', 'state_id' => 12],
+            ['name' => 'كلبس', 'state_id' => 12],
+            ['name' => 'مليط', 'state_id' => 12],
+
+            // شمال كردفان (13)
+            ['name' => 'أم دم', 'state_id' => 13],
+            ['name' => 'أم روابة', 'state_id' => 13],
+            ['name' => 'بارا', 'state_id' => 13],
+            ['name' => 'جبرة الشيخ', 'state_id' => 13],
+            ['name' => 'سودري', 'state_id' => 13],
+            ['name' => 'شيكان', 'state_id' => 13],
+            ['name' => 'كلبس', 'state_id' => 13],
+
+            // غرب دارفور (14)
+            ['name' => 'الجنينة', 'state_id' => 14],
+            ['name' => 'بيضة', 'state_id' => 14],
+            ['name' => 'جبل مون', 'state_id' => 14],
+            ['name' => 'سربا', 'state_id' => 14],
+            ['name' => 'قوز برنقا', 'state_id' => 14],
+            ['name' => 'كرينك', 'state_id' => 14],
+            ['name' => 'كلبس', 'state_id' => 14],
+            ['name' => 'هبيلة', 'state_id' => 14],
+
+            // كسلا (15)
+            ['name' => 'القاش', 'state_id' => 15],
+            ['name' => 'ريفي كسلا', 'state_id' => 15],
+            ['name' => 'كسلا', 'state_id' => 15],
+            ['name' => 'نهر عطبرة', 'state_id' => 15],
+            ['name' => 'همشكوريب', 'state_id' => 15],
+
+            // نهر النيل (16)
+            ['name' => 'المتمة', 'state_id' => 16],
+            ['name' => 'الدامر', 'state_id' => 16],
+            ['name' => 'أبو حمد', 'state_id' => 16],
+            ['name' => 'بربر', 'state_id' => 16],
+            ['name' => 'عطبرة', 'state_id' => 16],
+
+            // وسط دارفور (17)
+            ['name' => 'أزوم', 'state_id' => 17],
+            ['name' => 'أم دخن', 'state_id' => 17],
+            ['name' => 'بندسي', 'state_id' => 17],
+            ['name' => 'جبل مرة', 'state_id' => 17],
+            ['name' => 'روكورو', 'state_id' => 17],
+            ['name' => 'زالنجي', 'state_id' => 17],
+            ['name' => 'مكجر', 'state_id' => 17],
+            ['name' => 'وادي صالح', 'state_id' => 17],
+
+            // غرب كردفان (18)
+            ['name' => 'الفولة', 'state_id' => 18],
+            ['name' => 'النهود', 'state_id' => 18],
+            ['name' => 'أبيي', 'state_id' => 18],
+            ['name' => 'بابنوسة', 'state_id' => 18],
+            ['name' => 'هبيلا', 'state_id' => 18],
+        ];
+
+        foreach ($localities as $locality) {
+            Locality::create($locality);
+        }
+
+
+
+
+    }
+}

--- a/database/seeders/StateSeeder.php
+++ b/database/seeders/StateSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\State;
+
+class StateSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $states = [
+            ['name' => 'البحر الأحمر'],
+            ['name' => 'الجزيرة'],
+            ['name' => 'الخرطوم'],
+            ['name' => 'الشمالية'],
+            ['name' => 'القضارف'],
+            ['name' => 'النيل الأبيض'],
+            ['name' => 'النيل الأزرق'],
+            ['name' => 'جنوب دارفور'],
+            ['name' => 'جنوب كردفان'],
+            ['name' => 'سنار'],
+            ['name' => 'شرق دارفور'],
+            ['name' => 'شمال دارفور'],
+            ['name' => 'شمال كردفان'],
+            ['name' => 'غرب دارفور'],
+            ['name' => 'كسلا'],
+            ['name' => 'نهر النيل'],
+            ['name' => 'وسط دارفور'],
+            ['name' => 'غرب كردفان'],
+        ];
+        foreach ($states as $state) {
+            State::create($state);
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request introduces dynamic support for states and localities within the application. Previously, these entities were statically defined as HTML dropdown lists. With this change, we have created models for states and localities (State.php and Locality.php respectively) to manage their data more efficiently. Additionally, migrations have been created (create_states_table.php and create_localities_table.php) to establish the necessary database structure. Furthermore, seeders (StateSeeder.php and LocalitySeeder.php) have been implemented to populate the states and localities dynamically. Finally, modifications have been made to DatabaseSeeder.php to include calls to these new seeders. Overall, this enhancement allows for a more flexible and scalable approach to managing states and localities within the application.






