### PR TITLE
Implement dynamic dropdowns for states and localities in shipment forms and details

### DIFF
--- a/app/Http/Controllers/ShipmentsController.php
+++ b/app/Http/Controllers/ShipmentsController.php
@@ -32,6 +32,8 @@ class ShipmentsController extends Controller
             'sender.address',
             'recipient',
             'recipient.address',
+            'recipient.address.state',
+            'recipient.address.locality',
             'recipient.facility'
         ])->get();
 
@@ -77,15 +79,15 @@ class ShipmentsController extends Controller
             'senderName' => 'required|string',
             'senderEmail' => 'required|email',
             'senderPhone' => 'required|string',
-            'senderState' => 'required|string',
-            'senderCity' => 'required|string',
+            'senderState' => 'required|numeric',
+            'senderLocality' => 'required|numeric',
             'senderStreet' => 'required|string',
             'senderAddressDetails' => 'nullable|string',
             'recipientName' => 'required|string',
             'recipientEmail' => 'required|email',
             'recipientPhone' => 'required|string',
-            'recipientState' => 'required|string',
-            'recipientCity' => 'required|string',
+            'recipientState' => 'required|numeric',
+            'recipientLocality' => 'required|numeric',
             'recipientStreet' => 'required|string',
             'recipientAddressDetails' => 'nullable|string',
             'recipientNearFacility' => 'required|numeric',
@@ -94,16 +96,16 @@ class ShipmentsController extends Controller
         // Create an address for the sender
         $senderAddress = new Address();
         $senderAddress->street = $validatedData['senderStreet'];
-        $senderAddress->city = $validatedData['senderCity'];
-        $senderAddress->state = $validatedData['senderState'];
+        $senderAddress->state_id = $validatedData['senderState'];
+        $senderAddress->locality_id = $validatedData['senderLocality'];
         $senderAddress->details = $validatedData['senderAddressDetails'];
         $senderAddress->save();
 
         // Create an address for the recipient
         $recipientAddress = new Address();
         $recipientAddress->street = $validatedData['recipientStreet'];
-        $recipientAddress->city = $validatedData['recipientCity'];
-        $recipientAddress->state = $validatedData['recipientState'];
+        $recipientAddress->state_id = $validatedData['recipientState'];
+        $recipientAddress->locality_id = $validatedData['recipientLocality'];
         $recipientAddress->details = $validatedData['recipientAddressDetails'];
         $recipientAddress->save();
 
@@ -176,16 +178,16 @@ class ShipmentsController extends Controller
             'sender.email' => 'required|email',
             'sender.phone' => 'required|string',
             'sender.address.street' => 'required|string',
-            'sender.address.city' => 'required|string',
-            'sender.address.state' => 'required|string',
+            'sender.address.state_id' => 'required|numeric',
+            'sender.address.locality_id' => 'required|numeric',
             'sender.address.details' => 'required|string',
             'recipient.name' => 'required|string',
             'recipient.email' => 'required|email',
             'recipient.phone' => 'required|string',
             'recipient.address.details' => 'required|string',
             'recipient.address.street' => 'required|string',
-            'recipient.address.city' => 'required|string',
-            'recipient.address.state' => 'required|string',
+            'recipient.address.state_id' => 'required|numeric',
+            'recipient.address.locality_id' => 'required|numeric',
             'recipient.facility.id' => 'required|numeric',
         ]);
 
@@ -205,8 +207,8 @@ class ShipmentsController extends Controller
         // Update the sender's address
         $shipment->sender->address->update([
             'street' => $validatedData['sender']['address']['street'],
-            'city' => $validatedData['sender']['address']['city'],
-            'state' => $validatedData['sender']['address']['state'],
+            'state_id' => $validatedData['sender']['address']['state_id'],
+            'locality_id' => $validatedData['sender']['address']['locality_id'],
             'details' => $validatedData['sender']['address']['details'],
         ]);
 
@@ -221,8 +223,8 @@ class ShipmentsController extends Controller
         // Update the recipient's address
         $shipment->recipient->address->update([
             'street' => $validatedData['recipient']['address']['street'],
-            'city' => $validatedData['recipient']['address']['city'],
-            'state' => $validatedData['recipient']['address']['state'],
+            'state_id' => $validatedData['recipient']['address']['state_id'],
+            'locality_id' => $validatedData['recipient']['address']['locality_id'],
             'details' => $validatedData['recipient']['address']['details'],
         ]);
 

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -24,11 +24,11 @@ class Address extends Model
 
     public function state()
     {
-        return $this->belongsTo(State::class);
+        return $this->belongsTo(State::class, 'state_id');
     }
 
     public function locality()
     {
-        return $this->belongsTo(Locality::class);
+        return $this->belongsTo(Locality::class, 'locality_id');
     }
 }

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\State;
+use App\Models\Locality;
 
 class Address extends Model
 {
@@ -15,8 +17,18 @@ class Address extends Model
      */
     protected $fillable = [
         'street',
-        'city',
-        'state',
+        'state_id',
+        'locality_id',
         'details',
     ];
+
+    public function state()
+    {
+        return $this->belongsTo(State::class);
+    }
+
+    public function locality()
+    {
+        return $this->belongsTo(Locality::class);
+    }
 }

--- a/resources/js/Pages/AddShipmentComponent.vue
+++ b/resources/js/Pages/AddShipmentComponent.vue
@@ -25,7 +25,7 @@ const form = useForm({
     recipientEmail: '',
     recipientPhone: '',
     recipientState: '',
-    recipientCity: '',
+    recipientLocality: '',
     recipientStreet: '',
     recipientAddressDetails: '',
     recipientNearFacility: ''

--- a/resources/js/Pages/ShipmentQrComponent.vue
+++ b/resources/js/Pages/ShipmentQrComponent.vue
@@ -16,8 +16,8 @@
                     <p><strong>Item Name:</strong> {{ shipment.item.name }}</p>
                     <p><strong>Sender:</strong> {{ shipment.sender.name }}</p>
                     <p><strong>Recipient:</strong> {{ shipment.recipient.name }} - {{ shipment.recipient.phone }}</p>
-                    <p><strong>Address:</strong> {{ shipment.recipient.address.state }} -
-                        {{ shipment.recipient.address.city }} -
+                    <p><strong>Address:</strong> {{ shipment.recipient.address.state.name }} -
+                        {{ shipment.recipient.address.locality.name }} -
                         {{ shipment.recipient.address.street }} - {{ shipment.recipient.address.details }}</p>
                 </div>
                 <!-- Display QR code -->


### PR DESCRIPTION
This pull request introduces dynamic dropdown menus for selecting states and localities in both the shipment creation and details components. Here's a breakdown of the changes:

**1. ShipmentsController.php:**

* Updated validation rules to accept numeric values for senderState and recipientState, and senderLocality and recipientLocality.
* Modified store and update methods to handle state_id and locality_id instead of state and city fields.

**2. Address.php:**

* Updated the state() and locality() relationships to use the correct foreign key names for state_id and locality_id.

**3. AddShipmentComponent.vue:**

* Refactored the senderState, recipientState, senderLocality, and recipientLocality fields to accept numeric values.
* Integrated dynamic dropdown menus for selecting states and localities retrieved from the backend API.

**4. ShipmentQrComponent.vue:**

* Updated the template to display the name of the state and locality instead of state and city for recipient address.

**5. ShipmentDetailsComponent.vue:**

* Implemented dynamic dropdowns for selecting states and localities in the shipment details modal.
* Updated the modal to fetch and display the appropriate localities based on the selected state for both sender and recipient addresses.

These changes enhance the user experience by allowing the selection of states and localities from dynamically populated dropdown menus, providing more accurate and user-friendly data input and display options.