### PR TITLE
Separate Current Facility from User in Shipment Management

### DIFF
--- a/app/Http/Controllers/ShipmentsController.php
+++ b/app/Http/Controllers/ShipmentsController.php
@@ -52,6 +52,7 @@ class ShipmentsController extends Controller
             'recipient.facility',
             'user.facility',
             'facility',
+            'currentFacility',
             'status'
         ])->where('tracking_token', $token)->first();
 
@@ -71,6 +72,7 @@ class ShipmentsController extends Controller
         // Get the current user ID
         $userId = auth()->user()->id;
         $origin_facility = auth()->user()->facility_id;
+        $current_facility = auth()->user()->facility_id;
 
         // Validate incoming request data
         $validatedData = $request->validate([
@@ -141,6 +143,7 @@ class ShipmentsController extends Controller
         $shipment->tracking_token = $trackingToken; // Assign the tracking token
         $shipment->user_id = $userId; // Assign the current user ID
         $shipment->origin_facility_id = $origin_facility; // Assign the current user facility ID
+        $shipment->current_facility_id = $current_facility; // Assign the current user facility ID
 
         // Generate QR code content (URL)
         $qrCodeContent = route('shipments.update_status_via_qr', ['tracking_token' => $trackingToken]);
@@ -246,6 +249,7 @@ class ShipmentsController extends Controller
             // Update the shipment status
             $shipment->status_id = $validatedData['status_id'];
             $shipment->user_id = auth()->user()->id;
+            $shipment->current_facility_id = auth()->user()->facility_id;
             $shipment->save();
             if ($shipment->recipient->near_facility_id === auth()->user()->facility_id)
             {
@@ -288,6 +292,7 @@ class ShipmentsController extends Controller
                     // Change the shipment to out for delivery and change the user_id
                     $shipmentDetails->status_id = 3;
                     $shipmentDetails->user_id = auth()->user()->id;
+                    $shipmentDetails->current_facility_id = auth()->user()->facility_id;
                     // Send email notification to sender
                     Mail::to($shipmentDetails->sender->email)->send(new SenderShipmentOutForDelivery($shipmentDetails));
                     // Send email notification to recipient
@@ -298,6 +303,7 @@ class ShipmentsController extends Controller
                     // Change the shipment to Delivered and change the user_id
                     $shipmentDetails->status_id = 4;
                     $shipmentDetails->user_id = auth()->user()->id;
+                    $shipmentDetails->current_facility_id = auth()->user()->facility_id;
                     // Send email notification to sender
                     Mail::to($shipmentDetails->sender->email)->send(new ShipmentDelivered($shipmentDetails, $shipmentDetails->sender->name));
                     // Send email notification to recipient
@@ -310,6 +316,7 @@ class ShipmentsController extends Controller
                     // Change the shipment to Pending and change the user_id
                     $shipmentDetails->status_id = 1;
                     $shipmentDetails->user_id = auth()->user()->id;
+                    $shipmentDetails->current_facility_id = auth()->user()->facility_id;
                 }
             }
             // If the shipment is not at the last facility
@@ -319,10 +326,12 @@ class ShipmentsController extends Controller
                     // Change the shipment to In Transit and change the user_id
                     $shipmentDetails->status_id = 2;
                     $shipmentDetails->user_id = auth()->user()->id;
+                    $shipmentDetails->current_facility_id = auth()->user()->facility_id;
                 } else {
                     // Change the shipment to Pending and change the user_id
                     $shipmentDetails->status_id = 1;
                     $shipmentDetails->user_id = auth()->user()->id;
+                    $shipmentDetails->current_facility_id = auth()->user()->facility_id;
                 }
             }
             $shipmentDetails->save();

--- a/app/Models/Shipment.php
+++ b/app/Models/Shipment.php
@@ -47,6 +47,7 @@ class Shipment extends Model
         'user_id',
         'status_id',
         'origin_facility_id',
+        'current_facility_id',
         'tracking_token',
         'qr_code_image',
     ];
@@ -79,5 +80,10 @@ class Shipment extends Model
     public function facility()
     {
         return $this->belongsTo(Facility::class, 'origin_facility_id');
+    }
+
+    public function currentFacility()
+    {
+        return $this->belongsTo(Facility::class, 'current_facility_id');
     }
 }

--- a/database/migrations/2024_02_10_164243_create_shipments_table.php
+++ b/database/migrations/2024_02_10_164243_create_shipments_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->bigInteger('user_id')->unsigned();
             $table->BigInteger('status_id')->unsigned()->default(1); // Set default value to 1
             $table->BigInteger('origin_facility_id')->unsigned();
+            $table->BigInteger('current_facility_id')->unsigned();
             $table->string('tracking_token');
             $table->string('qr_code_image');
             $table->timestamps();
@@ -29,6 +30,7 @@ return new class extends Migration
             $table->foreign('status_id')->references('id')->on('statuses')->onDelete('cascade');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('origin_facility_id')->references('id')->on('facilities')->onDelete('cascade');
+            $table->foreign('current_facility_id')->references('id')->on('facilities')->onDelete('cascade');
 
         });
     }

--- a/resources/js/Pages/Tracking.vue
+++ b/resources/js/Pages/Tracking.vue
@@ -17,7 +17,7 @@ onMounted(async () => {
         const citiesResponse = await axios.get('/api/cities');
         cities.value = citiesResponse.data;
     } catch (error) {
-        console.error('Error fetching data:', error);
+        alert('Error fetching data:', error);
     }
 
 });
@@ -28,7 +28,7 @@ const searchByToken = async () => {
         const shipmentsResponse = await axios.get(`/api/shipments/${token.value.trim()}`);
         shipments.value = shipmentsResponse.data;
         routeCities.value = findRoute(shipments.value.facility.location, shipments.value.recipient.facility.location, cities.value);
-        currentCityPosition.value = routeCities.value.indexOf(shipments.value.user.facility.location);
+        currentCityPosition.value = routeCities.value.indexOf(shipments.value.current_facility.location);
 
         // Ensure that the current city is found in the routeCities array
         if (currentCityPosition.value !== -1) {
@@ -44,7 +44,7 @@ function findRoute(startingPoint, destinationPoint, cities) {
     // Check if cities is an array and convert to an array if it's not
     if (!Array.isArray(cities)) {
         // Log an error and return an empty route
-        console.error("Cities data is not an array");
+        alert("Cities data is not an array");
         return [];
     }
 
@@ -56,7 +56,7 @@ function findRoute(startingPoint, destinationPoint, cities) {
 
     // Check if the starting city exists
     if (!startingCity) {
-        console.error("Starting city not found in the cities data");
+        alert("Starting city not found in the cities data");
         return [];
     }
 
@@ -78,7 +78,7 @@ function findRoute(startingPoint, destinationPoint, cities) {
         // Check if the next city exists
         if (!nextCity || route.includes(nextCity.city_name)) {
             // Cyclic route or destination not found, break the loop
-            console.error("Cyclic route or destination not found");
+            alert("Cyclic route or destination not found");
             break;
         }
 


### PR DESCRIPTION
This pull request addresses an issue where changes in user facilities were affecting active shipments, leading to tracking inaccuracies. To resolve this, the following changes have been made:

**1. Added 'current_facility_id' Column:**

* In the database/migrations/2024_02_10_164243_create_shipments_table.php migration file, a new column current_facility_id has been added to the shipments table.
* This column will store the ID of the facility where the shipment is currently located.

**2. Updated ShipmentsController:**

* Modified ShipmentsController.php to handle the assignment of current_facility_id when updating the shipment status.
* The store() and updateStatus() methods now assign the current user's facility ID to the current_facility_id column of the shipment.

**3, Updated Shipment Model:**

* In the app/Models/Shipment.php model, the current_facility_id field has been added to the $fillable property to allow mass assignment.

**4. Revised Tracking.vue Component:**

* Adjusted the logic in resources/js/Pages/Tracking.vue to utilize the current_facility_id when determining the current city position for tracking purposes.

These changes ensure that the current facility of a shipment is accurately recorded and tracked independent of user facility changes, enhancing the reliability and accuracy of the shipment management system.