### PR TITLE
Add QR code image deletion on shipment deletion

### DIFF
--- a/app/Http/Controllers/ShipmentsController.php
+++ b/app/Http/Controllers/ShipmentsController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
 use Illuminate\Http\Request;
 use App\Models\Address;
 use App\Models\Item;
@@ -20,7 +19,7 @@ use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\Image\SvgImageBackEnd;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\File;
 
 class ShipmentsController extends Controller
 {
@@ -374,7 +373,7 @@ class ShipmentsController extends Controller
         }
     }
 
-    public function destroy($id)
+    public function destroy(Request $request, $id)
     {
         // Find the shipment by id
         $shipment = Shipment::with('user', 'item', 'sender', 'recipient')->findOrFail($id);
@@ -385,6 +384,14 @@ class ShipmentsController extends Controller
 
         // Get the current user ID
         $userId = $request->user()->id;
+
+        // Get the path of the QR code image
+        $qrCodeImagePath = public_path($shipment->qr_code_image);
+
+        // Check if the QR code image file exists, then delete it
+        if (File::exists($qrCodeImagePath)) {
+            File::delete($qrCodeImagePath);
+        }
 
         // Create log
         $shipment->createLog($userId, $shipment->id, $shipment->tracking_token, 'delete', $oldData, $newData);


### PR DESCRIPTION
In the ShipmentsController, an enhancement has
been made to ensure that the QR code image
associated with a shipment is deleted when the
shipment is deleted. Previously, only the shipment data was removed upon deletion, leaving the
associated QR code image intact. Now, upon deletion of a shipment, the controller checks for the
existence of the QR code image file and deletes it if found, ensuring that all related data, including the image, is properly removed.

Changes:
- Imported the File facade from Illuminate\Support\Facades\File.
- Modified the destroy method to accept a Request object.
- Added logic to delete the QR code image file associated with the shipment upon deletion.

This enhancement improves data integrity and ensures that no unnecessary files are left behind when
a shipment is deleted.